### PR TITLE
Make compatible with pydocstyle > 1.1.1

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -28,7 +28,7 @@ class Pydocstyle(PythonLinter):
     regex = r'^.+?:(?P<line>\d+).*:\r?\n\s*(?P<message>.+)$'
     multiline = True
     default_type = highlight.WARNING
-    error_stream = util.STREAM_STDERR
+    error_stream = util.STREAM_BOTH
     line_col_base = (0, 0)  # pydocstyle uses one-based line and zero-based column numbers
     tempfile_suffix = 'py'
     defaults = {


### PR DESCRIPTION
Fixes the compatibility issue with pydocstyle > 1.1.1.

_Pydocstyle 2.0.0_ now also uses `STREAM_STDOUT` instead of only `STREAM_STDERR`.
As of now it sees no error output and doesnt trigger a response, this should fix it