### PR TITLE
Add standard mypy configuration

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,17 @@
+[mypy]
+check_untyped_defs = True
+warn_redundant_casts = True
+warn_unused_ignores = True
+mypy_path =
+  :$MYPY_CONFIG_FILE_DIR/../
+  :$MYPY_CONFIG_FILE_DIR/../SublimeLinter/stubs
+sqlite_cache = True
+
+[mypy-Default]
+ignore_missing_imports = True
+
+[mypy-unittesting]
+ignore_missing_imports = True
+
+[mypy-package_control]
+ignore_missing_imports = True


### PR DESCRIPTION
This is only used locally during development.  We can't have a GitHub action because we would need to install SublimeLinter as well.