### PR TITLE
Use actual filename for the temporary files

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -1,3 +1,7 @@
+from contextlib import contextmanager
+import os
+import tempfile
+
 from SublimeLinter.lint import PythonLinter
 from SublimeLinter.lint.linter import TransientError
 
@@ -21,6 +25,38 @@ class Pydocstyle(PythonLinter):
         '--convention=': '',
         '--ignore-decorators=': ''
     }
+
+    def tmpfile(self, cmd, code, suffix=None):
+        filename = (
+            self.context.get('file_name')
+            or "{}{}".format(
+                self.context['canonical_filename'][1:-1],
+                suffix or self.get_tempfile_suffix()
+            )
+        )
+        with self._make_temp_file(filename, code) as temp_filename:
+            self.context['file_on_disk'] = self.filename
+            self.context['temp_file'] = temp_filename
+            cmd = self.finalize_cmd(
+                cmd, self.context, at_value=temp_filename, auto_append=True)
+            return self._communicate(cmd)
+
+    @contextmanager
+    def _make_temp_file(self, filename, code):
+        folder_prefix = "{}-".format(self.plugin_name)
+        with tempfile.TemporaryDirectory(prefix=folder_prefix) as tmp_dir_name:
+            temp_filename = os.path.join(tmp_dir_name, filename)
+            with open(temp_filename, "w+b") as file:
+                file.write(bytes(code, "utf-8"))
+
+            try:
+                yield temp_filename
+            finally:
+                os.remove(temp_filename)
+
+    @property
+    def plugin_name(self):
+        return self.__class__.__module__.split(".", 1)[0]
 
     def on_stderr(self, stderr):
         # For a doc style tester, parse errors can be treated 'transient',


### PR DESCRIPTION
Fixes #29

pydocstyle actually uses the filename to decide if or how some rules
apply.  For example it treats `__init__.py` and `_some_module.py`
differently.

Instead of generating a random filename, generate a randomly named
directory with the actual file in it.